### PR TITLE
Update spl token dependency to 0.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@solana/spl-token": "^0.0.13",
+    "@solana/spl-token": "^0.1.8",
     "bn.js": "^5.1.3",
     "decimal.js": "^10.2.1"
   },


### PR DESCRIPTION
 Old spl token library create dependencies on multiple node modules:
 - https
 - http
 - process

As a result Orca SDK will not work with React Native

Newer spl-token library doesn't have direct node dependencies, which fixes the problem