### PR TITLE
bump to v1.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/stablecurve",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Helper functions for dealing with stablecurve",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
A dependent version of spl-token is updated to ^0.1.8, but not released yet.
u64, an extension of BN,  is used, and is not affected by this change.