### PR TITLE
bump to v1.0.8: add files field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/stablecurve",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Helper functions for dealing with stablecurve",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -15,6 +15,9 @@
     "bn.js": "^5.1.3",
     "decimal.js": "^10.2.1"
   },
+  "files": [
+    "/dist"
+  ],
   "devDependencies": {
     "@types/bn.js": "^5.1.0",
     "@types/node-fetch": "^2.6.2",


### PR DESCRIPTION
- Added a files field to package.json to specify which files to package
- v1.0.7 is deprecated due to missing packaged files